### PR TITLE
[WIP][ID-19]"ホームに戻る"をボタンコンポーネントに置換#22

### DIFF
--- a/src/app/(static)/about/page.tsx
+++ b/src/app/(static)/about/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Button } from '@/components/ui/button';
 
 export default function CompanyInfo() {
   return (
@@ -26,8 +27,8 @@ export default function CompanyInfo() {
       </p>
 
       <p className='text-center'>
-        <Link href='/' className='text-blue-600 hover:underline'>
-          ホームに戻る
+        <Link href='/'>
+          <Button size='lg'>ホームに戻る</Button>
         </Link>
       </p>
     </div>

--- a/src/app/(static)/about/page.tsx
+++ b/src/app/(static)/about/page.tsx
@@ -20,7 +20,7 @@ export default function CompanyInfo() {
       </p>
 
       <h2 className='mb-2 text-sm'>連絡先</h2>
-      <p className='mb-10 border-b pb-5'>
+      <p className='mb-20 border-b pb-5'>
         メールアドレス: info@moodify.com
         <br />
         ※お問い合わせはメールでのみ受け付けております。

--- a/src/app/(static)/about/page.tsx
+++ b/src/app/(static)/about/page.tsx
@@ -20,7 +20,7 @@ export default function CompanyInfo() {
       </p>
 
       <h2 className='mb-2 text-sm'>連絡先</h2>
-      <p className='mb-20 border-b pb-5'>
+      <p className='mb-10 border-b pb-5'>
         メールアドレス: info@moodify.com
         <br />
         ※お問い合わせはメールでのみ受け付けております。

--- a/src/app/(static)/about/page.tsx
+++ b/src/app/(static)/about/page.tsx
@@ -27,9 +27,9 @@ export default function CompanyInfo() {
       </p>
 
       <p className='text-center'>
-        <Link href='/'>
-          <Button size='lg'>ホームに戻る</Button>
-        </Link>
+        <Button size='lg'>
+          <Link href='/'>ホームに戻る</Link>
+        </Button>
       </p>
     </div>
   );

--- a/src/app/(static)/about/page.tsx
+++ b/src/app/(static)/about/page.tsx
@@ -20,7 +20,7 @@ export default function CompanyInfo() {
       </p>
 
       <h2 className='mb-2 text-sm'>連絡先</h2>
-      <p className='mb-5 border-b pb-5'>
+      <p className='mb-10 border-b pb-5'>
         メールアドレス: info@moodify.com
         <br />
         ※お問い合わせはメールでのみ受け付けております。

--- a/src/app/(static)/notice/page.tsx
+++ b/src/app/(static)/notice/page.tsx
@@ -38,8 +38,8 @@ export default function LegalNotice() {
       </p>
 
       <p className='text-center'>
-        <Link href='/' className='text-blue-600 hover:underline'>
-          <Button>ホームに戻る</Button>
+        <Link href='/'>
+          <Button size='lg'>ホームに戻る</Button>
         </Link>
       </p>
     </div>

--- a/src/app/(static)/notice/page.tsx
+++ b/src/app/(static)/notice/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Button } from '@/components/ui/button';
 
 export default function LegalNotice() {
   return (
@@ -38,7 +39,7 @@ export default function LegalNotice() {
 
       <p className='text-center'>
         <Link href='/' className='text-blue-600 hover:underline'>
-          ホームに戻る
+          <Button>ホームに戻る</Button>
         </Link>
       </p>
     </div>

--- a/src/app/(static)/notice/page.tsx
+++ b/src/app/(static)/notice/page.tsx
@@ -38,9 +38,9 @@ export default function LegalNotice() {
       </p>
 
       <p className='text-center'>
-        <Link href='/'>
-          <Button size='lg'>ホームに戻る</Button>
-        </Link>
+        <Button size='lg'>
+          <Link href='/'>ホームに戻る</Link>
+        </Button>
       </p>
     </div>
   );

--- a/src/app/(static)/notice/page.tsx
+++ b/src/app/(static)/notice/page.tsx
@@ -33,7 +33,7 @@ export default function LegalNotice() {
       </p>
 
       <h2 className='mb-2 text-sm'>返品・キャンセルについて</h2>
-      <p className='mb-5 border-b pb-5'>
+      <p className='mb-10 border-b pb-5'>
         デジタルコンテンツの性質上、購入後のキャンセル・返品はお受けできません。
       </p>
 

--- a/src/app/(static)/policy/page.tsx
+++ b/src/app/(static)/policy/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-
+import { Button } from '@/components/ui/button';
 export default function PrivacyPolicy() {
   return (
     <div className='container mx-0 max-w-md px-4 py-10 text-sm leading-6 tracking-widest md:mx-auto md:max-w-xl'>
@@ -33,8 +33,8 @@ export default function PrivacyPolicy() {
         当サービスは、必要に応じて本ポリシーを変更することがあります。変更後のポリシーは、本ページで公開された時点で効力を生じるものとします。
       </p>
       <p className='text-center'>
-        <Link href='/' className='text-blue-600 hover:underline'>
-          ホームに戻る
+        <Link href='/'>
+          <Button size='lg'>ホームに戻る</Button>
         </Link>
       </p>
     </div>

--- a/src/app/(static)/policy/page.tsx
+++ b/src/app/(static)/policy/page.tsx
@@ -33,9 +33,9 @@ export default function PrivacyPolicy() {
         当サービスは、必要に応じて本ポリシーを変更することがあります。変更後のポリシーは、本ページで公開された時点で効力を生じるものとします。
       </p>
       <p className='text-center'>
-        <Link href='/'>
-          <Button size='lg'>ホームに戻る</Button>
-        </Link>
+        <Button size='lg'>
+          <Link href='/'>ホームに戻る</Link>
+        </Button>
       </p>
     </div>
   );

--- a/src/app/(static)/policy/page.tsx
+++ b/src/app/(static)/policy/page.tsx
@@ -29,7 +29,7 @@ export default function PrivacyPolicy() {
         法令に基づく場合を除き、ユーザーの同意なく第三者に個人情報を提供することはありません。
       </p>
       <h2 className='mb-4 bg-gray-100 p-2 text-base'>5. プライバシーポリシーの変更</h2>
-      <p className='mb-4'>
+      <p className='mb-10'>
         当サービスは、必要に応じて本ポリシーを変更することがあります。変更後のポリシーは、本ページで公開された時点で効力を生じるものとします。
       </p>
       <p className='text-center'>

--- a/src/app/(static)/terms/page.tsx
+++ b/src/app/(static)/terms/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-
+import { Button } from '@/components/ui/button';
 export default function TermsOfService() {
   return (
     <div className='container mx-0 max-w-md px-4 py-10 text-sm leading-6 tracking-widest md:mx-auto md:max-w-xl'>
@@ -33,8 +33,8 @@ export default function TermsOfService() {
         当サービスは、ユーザーに通知することなく、本サービスの内容を変更しまたは本サービスの提供を中止することができるものとし、これによってユーザーに生じた損害について一切の責任を負いません。
       </p>
       <p className='text-center'>
-        <Link href='/' className='text-blue-600 hover:underline'>
-          ホームに戻る
+        <Link href='/'>
+          <Button size='lg'>ホームに戻る</Button>
         </Link>
       </p>
     </div>

--- a/src/app/(static)/terms/page.tsx
+++ b/src/app/(static)/terms/page.tsx
@@ -29,7 +29,7 @@ export default function TermsOfService() {
         <br />- 他のユーザーに関する個人情報等を収集または蓄積する行為
       </p>
       <h2 className='mb-4 bg-gray-100 p-2 text-base'>5. サービス内容の変更等</h2>
-      <p className='mb-4'>
+      <p className='mb-10'>
         当サービスは、ユーザーに通知することなく、本サービスの内容を変更しまたは本サービスの提供を中止することができるものとし、これによってユーザーに生じた損害について一切の責任を負いません。
       </p>
       <p className='text-center'>

--- a/src/app/(static)/terms/page.tsx
+++ b/src/app/(static)/terms/page.tsx
@@ -33,9 +33,9 @@ export default function TermsOfService() {
         当サービスは、ユーザーに通知することなく、本サービスの内容を変更しまたは本サービスの提供を中止することができるものとし、これによってユーザーに生じた損害について一切の責任を負いません。
       </p>
       <p className='text-center'>
-        <Link href='/'>
-          <Button size='lg'>ホームに戻る</Button>
-        </Link>
+        <Button size='lg'>
+          <Link href='/'>ホームに戻る</Link>
+        </Button>
       </p>
     </div>
   );


### PR DESCRIPTION
## 対応内容の概要

<!-- 変更内容を簡潔に記載してください -->

- サービスページ「運営者情報」「特定商取引に基づく表記」「利用規約」「プライバシーポリシー」に
”Button component”を追加
- ボタンのスタイルをmainページと統一

Notionタスク: https://www.notion.so/4920d29859bc4e7daffa0d283ab6152d<!-- タスクページへのリンクを記載してください -->

## 確認項目

<!-- 動作確認した項目をチェックリストで記載してください -->

- ページ遷移が正しく行われるか 
- ボタンが正しいスタイルで表示されているか（大きさ、色、中央揃え）
- lint,build,formatのコマンドは実行されているか

## スクリーンショット（UI変更がある場合）

<!-- UI の変更がある場合は、各デバイスのスクリーンショットを添付してください -->

| PC                        | 
<img width="1704" alt="スクリーンショット 2025-01-05 13 57 23" src="https://github.com/user-attachments/assets/9714bcf7-d759-45ea-baa0-c51de66b50d7" />


|モバイル                  |
<img width="372" alt="スクリーンショット 2025-01-05 13 57 30" src="https://github.com/user-attachments/assets/a0cebd5a-329b-42b2-9116-f9319f27e0ae" />


## #22

<!--
  close: #issue番号 の形式で記載することで、PRがマージされた際に自動でissueがクローズされます
  複数のissueを閉じる場合は以下のいずれかの形式で記載してください：
  - close: #123 #456 #789
  - close: #123, close: #456, close: #789
-->

close: #22

## セルフチェック

- [x] Reviewersに担当者を指定した
- [x] Assigneesに自分を指定した
- [x] Labelsに適切なラベルを指定した
- [x] PRのタイトルにNotion IDを付与した
- [x] WIPの場合、タイトルに[WIP]を付けた
- [x] レビュー依頼時、タイトルから[WIP]を削除した
