### PR TITLE
[WIP][ID-5]フッター下線調整#21

### DIFF
--- a/src/app/(static)/about/page.tsx
+++ b/src/app/(static)/about/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Button } from '@/components/ui/button';
 
 export default function CompanyInfo() {
   return (
@@ -26,8 +27,8 @@ export default function CompanyInfo() {
       </p>
 
       <p className='text-center'>
-        <Link href='/' className='text-blue-600 hover:underline'>
-          ホームに戻る
+        <Link href='/'>
+          <Button size='lg'>ホームに戻る</Button>
         </Link>
       </p>
     </div>

--- a/src/app/(static)/notice/page.tsx
+++ b/src/app/(static)/notice/page.tsx
@@ -38,8 +38,8 @@ export default function LegalNotice() {
       </p>
 
       <p className='text-center'>
-        <Link href='/' className='text-blue-600 hover:underline'>
-          <Button>ホームに戻る</Button>
+        <Link href='/'>
+          <Button size='lg'>ホームに戻る</Button>
         </Link>
       </p>
     </div>

--- a/src/app/(static)/notice/page.tsx
+++ b/src/app/(static)/notice/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Button } from '@/components/ui/button';
 
 export default function LegalNotice() {
   return (
@@ -38,7 +39,7 @@ export default function LegalNotice() {
 
       <p className='text-center'>
         <Link href='/' className='text-blue-600 hover:underline'>
-          ホームに戻る
+          <Button>ホームに戻る</Button>
         </Link>
       </p>
     </div>

--- a/src/app/(static)/policy/page.tsx
+++ b/src/app/(static)/policy/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-
+import { Button } from '@/components/ui/button';
 export default function PrivacyPolicy() {
   return (
     <div className='container mx-0 max-w-md px-4 py-10 text-sm leading-6 tracking-widest md:mx-auto md:max-w-xl'>
@@ -33,8 +33,8 @@ export default function PrivacyPolicy() {
         当サービスは、必要に応じて本ポリシーを変更することがあります。変更後のポリシーは、本ページで公開された時点で効力を生じるものとします。
       </p>
       <p className='text-center'>
-        <Link href='/' className='text-blue-600 hover:underline'>
-          ホームに戻る
+        <Link href='/'>
+          <Button size='lg'>ホームに戻る</Button>
         </Link>
       </p>
     </div>

--- a/src/app/(static)/terms/page.tsx
+++ b/src/app/(static)/terms/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-
+import { Button } from '@/components/ui/button';
 export default function TermsOfService() {
   return (
     <div className='container mx-0 max-w-md px-4 py-10 text-sm leading-6 tracking-widest md:mx-auto md:max-w-xl'>
@@ -33,8 +33,8 @@ export default function TermsOfService() {
         当サービスは、ユーザーに通知することなく、本サービスの内容を変更しまたは本サービスの提供を中止することができるものとし、これによってユーザーに生じた損害について一切の責任を負いません。
       </p>
       <p className='text-center'>
-        <Link href='/' className='text-blue-600 hover:underline'>
-          ホームに戻る
+        <Link href='/'>
+          <Button size='lg'>ホームに戻る</Button>
         </Link>
       </p>
     </div>

--- a/src/components/common/MainFooter.tsx
+++ b/src/components/common/MainFooter.tsx
@@ -10,7 +10,7 @@ export function MainFooter() {
         <Link href='/policy'>プライバシーポリシー</Link>
         <Link href='/contact'>お問い合わせ</Link>
       </div>
-      <hr className='mx-auto my-4 w-10/12 border-gray-200'></hr>
+      <hr className='mx-auto my-4 w-11/12 border-gray-200 md:w-10/12'></hr>
       <p className='mb-1'>omoma © 2025</p>
     </footer>
   );


### PR DESCRIPTION
## 対応内容の概要

- モバイル時（デフォルト）の下線幅を90%以上（w-11/12）に変更
”11/12を%に計算すると91.666...なので、90%以上という計算です”

- md以降ではmd:w-10/12に調整

<!-- 変更内容を簡潔に記載してください -->
Notionタスク:https://www.notion.so/15a6eca2c93280a0ab92ec177f1e2037 <!-- タスクページへのリンクを記載してください -->

## 確認項目

<!-- 動作確認した項目をチェックリストで記載してください -->

- モバイル時と、md以降で下線幅が異なるか（レスポンスは効いているか）
- lint,build,formatのコマンドは実行されているか

## スクリーンショット（UI変更がある場合）

<!-- UI の変更がある場合は、各デバイスのスクリーンショットを添付してください -->

| PC                        | 
<img width="1653" alt="スクリーンショット 2025-01-03 15 33 55" src="https://github.com/user-attachments/assets/531f92aa-9a34-4215-a2e3-56ab72fc81f8" />

|モバイル                  |
<img width="388" alt="スクリーンショット 2025-01-03 16 43 21" src="https://github.com/user-attachments/assets/b2dbec01-37bd-4d51-8a8d-480a7202b87a" />


## #21 

<!--
  close: #issue番号 の形式で記載することで、PRがマージされた際に自動でissueがクローズされます
  複数のissueを閉じる場合は以下のいずれかの形式で記載してください：
  - close: #123 #456 #789
  - close: #123, close: #456, close: #789
-->

close: #21

## セルフチェック

- [x] Reviewersに担当者を指定した
- [x] Assigneesに自分を指定した
- [x] Labelsに適切なラベルを指定した
- [x] PRのタイトルにNotion IDを付与した
- [x] WIPの場合、タイトルに[WIP]を付けた
- [x] レビュー依頼時、タイトルから[WIP]を削除した
